### PR TITLE
fixed repo and branch display in push message

### DIFF
--- a/lib/interfaces/restify.js
+++ b/lib/interfaces/restify.js
@@ -127,7 +127,7 @@ function githubPush(data) {
 		},
 		function(callback) {
 
-			var message = "[\u000313" + data.repository.name + "/" + data.ref.split('/').pop() + "\u000f] \u000315" + data.head_commit.author.username + "\u000f pushed " + data.commits.length + " new commit(s) to master (+" + data.head_commit.added.length + " -" + data.head_commit.removed.length + " \u00B1" + data.head_commit.modified.length + ") " + shortenedURL;
+			var message = "[\u000313" + data.repository.full_name + "\u000f] \u000315" + data.head_commit.author.username + "\u000f pushed " + data.commits.length + " new commit(s) to " + data.ref.split('/').pop() + " (+" + data.head_commit.added.length + " -" + data.head_commit.removed.length + " \u00B1" + data.head_commit.modified.length + ") " + shortenedURL;
 
 			bot.say(config.irc.channel, message);
 


### PR DESCRIPTION
so this fixes the message when pushing a commit so it displays repo and branch correctly

I have seen in irc that this is indeed true:
data.ref.split('/').pop() = branch (kraken for example)
data.repository.full_name = user/repo (pufferpanel/scales for example)
